### PR TITLE
Fix Apple silicon temperature sensors

### DIFF
--- a/Core-Monitor.xcodeproj/project.pbxproj
+++ b/Core-Monitor.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		DABD00032F95000100000003 /* DashboardProcessSamplingPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DABD00012F95000100000001 /* DashboardProcessSamplingPolicyTests.swift */; };
 		DABD00042F95000100000004 /* HardwareRescueDiagnosticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DABD00022F95000100000002 /* HardwareRescueDiagnosticsTests.swift */; };
 		DABD10022F96000100000002 /* CoreMonitorShareKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DABD10012F96000100000001 /* CoreMonitorShareKitTests.swift */; };
+		DABD20022F97000100000002 /* SMCTemperatureSensorCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DABD20012F97000100000001 /* SMCTemperatureSensorCatalogTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -53,6 +54,7 @@
 		DABD00012F95000100000001 /* DashboardProcessSamplingPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardProcessSamplingPolicyTests.swift; sourceTree = "<group>"; };
 		DABD00022F95000100000002 /* HardwareRescueDiagnosticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HardwareRescueDiagnosticsTests.swift; sourceTree = "<group>"; };
 		DABD10012F96000100000001 /* CoreMonitorShareKitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreMonitorShareKitTests.swift; sourceTree = "<group>"; };
+		DABD20012F97000100000001 /* SMCTemperatureSensorCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SMCTemperatureSensorCatalogTests.swift; sourceTree = "<group>"; };
 		E5B12BED2CCB8BBEC03C227F /* Core-MonitorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Core-MonitorTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -103,6 +105,7 @@
 				DABD10012F96000100000001 /* CoreMonitorShareKitTests.swift */,
 				DABD00012F95000100000001 /* DashboardProcessSamplingPolicyTests.swift */,
 				DABD00022F95000100000002 /* HardwareRescueDiagnosticsTests.swift */,
+				DABD20012F97000100000001 /* SMCTemperatureSensorCatalogTests.swift */,
 			);
 			path = "Core-MonitorTests";
 			sourceTree = "<group>";
@@ -310,6 +313,7 @@
 				DABD10022F96000100000002 /* CoreMonitorShareKitTests.swift in Sources */,
 				DABD00032F95000100000003 /* DashboardProcessSamplingPolicyTests.swift in Sources */,
 				DABD00042F95000100000004 /* HardwareRescueDiagnosticsTests.swift in Sources */,
+				DABD20022F97000100000002 /* SMCTemperatureSensorCatalogTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Core-Monitor/MenuBarPopovers.swift
+++ b/Core-Monitor/MenuBarPopovers.swift
@@ -193,7 +193,7 @@ struct MetricPopoverView: View {
             if let efficiency = snapshot.efficiencyCoreUsagePercent {
                 stats.append(("Efficiency cores", ReadingFormat.percent(efficiency)))
             }
-            stats.append(("CPU temperature", ReadingFormat.celsiusLong(snapshot.cpuTemperature)))
+            stats.append(("CPU average temperature", ReadingFormat.celsiusLong(snapshot.cpuTemperature)))
             if let watts = snapshot.totalSystemWatts {
                 stats.append(("System power", ReadingFormat.watts(watts)))
             }
@@ -223,8 +223,8 @@ struct MetricPopoverView: View {
 
         case .temperature:
             var stats: [(String, String)] = [
-                ("GPU", ReadingFormat.celsiusLong(snapshot.gpuTemperature)),
-                ("SSD", ReadingFormat.celsiusLong(snapshot.ssdTemperature))
+                ("GPU average", ReadingFormat.celsiusLong(snapshot.gpuTemperature)),
+                (snapshot.storageTemperatureLabel, ReadingFormat.celsiusLong(snapshot.ssdTemperature))
             ]
             if let fastest = snapshot.fanSpeeds.filter({ $0 > 0 }).max() {
                 stats.append(("Fastest fan", ReadingFormat.rpm(fastest)))
@@ -237,7 +237,7 @@ struct MetricPopoverView: View {
                 let value = rpm < 0 ? "Unavailable" : (rpm > 0 ? ReadingFormat.rpm(rpm) : "At rest")
                 return ("Fan \(index + 1)", value)
             }
-            stats.append(("CPU temperature", ReadingFormat.celsiusLong(snapshot.cpuTemperature)))
+            stats.append(("CPU average temperature", ReadingFormat.celsiusLong(snapshot.cpuTemperature)))
             return stats
         }
     }

--- a/Core-Monitor/MonitorDesign.swift
+++ b/Core-Monitor/MonitorDesign.swift
@@ -333,8 +333,9 @@ struct TrendChart: View {
         let values = visible.map(\.value)
         let low = values.min() ?? 0
         let high = values.max() ?? 1
-        guard high > low else { return low - 1...high + 1 }
-        let padding = (high - low) * 0.15
+        let minimumPadding = 1.5
+        guard high > low else { return low - minimumPadding...high + minimumPadding }
+        let padding = max((high - low) * 0.15, minimumPadding)
         return (low - padding)...(high + padding)
     }
 }

--- a/Core-Monitor/MonitoringSnapshot.swift
+++ b/Core-Monitor/MonitoringSnapshot.swift
@@ -213,6 +213,8 @@ struct SystemMonitorSnapshot {
     var cpuPowerWatts: Double?
     var gpuPowerWatts: Double?
     var ssdTemperature: Double?
+    var storageTemperatureLabel: String = "Storage (SMC)"
+    var storageTemperatureNote: String?
     var networkStats = SystemMonitor.NetworkStats()
     var thermalState: ProcessInfo.ThermalState = .nominal
     var topProcesses: TopProcessSnapshot = .empty

--- a/Core-Monitor/SMCTemperatureSensors.swift
+++ b/Core-Monitor/SMCTemperatureSensors.swift
@@ -1,0 +1,171 @@
+import Foundation
+
+struct SMCStorageTemperatureSensor: Equatable, Sendable {
+    let key: String
+    let label: String
+}
+
+struct SMCTemperatureSensorSet: Equatable, Sendable {
+    let cpuKeys: [String]
+    let gpuKeys: [String]
+    let storageSensors: [SMCStorageTemperatureSensor]
+}
+
+enum SMCTemperatureSensorCatalog {
+    private nonisolated static let intelCPUKeys = [
+        "TC0P", "TCXC", "TC0E", "TC0F", "TC0D", "TC1C", "TC2C", "TC3C", "TC4C"
+    ]
+
+    private nonisolated static let intelGPUKeys = [
+        "TGDD", "TG0P", "TG0D", "TG0E", "TG0F"
+    ]
+
+    private nonisolated static let m1CPUKeys = [
+        "Tp09", "Tp0T", "Tp01", "Tp05", "Tp0D", "Tp0H", "Tp0L", "Tp0P", "Tp0X", "Tp0b"
+    ]
+
+    private nonisolated static let m1GPUKeys = [
+        "Tg05", "Tg0D", "Tg0L", "Tg0T"
+    ]
+
+    private nonisolated static let m2CPUKeys = [
+        "Tp1h", "Tp1t", "Tp1p", "Tp1l",
+        "Tp01", "Tp05", "Tp09", "Tp0D", "Tp0X", "Tp0b", "Tp0f", "Tp0j"
+    ]
+
+    private nonisolated static let m2GPUKeys = [
+        "Tg0f", "Tg0j"
+    ]
+
+    private nonisolated static let m3CPUKeys = [
+        "Te05", "Te0L", "Te0P", "Te0S",
+        "Tf04", "Tf09", "Tf0A", "Tf0B", "Tf0D", "Tf0E",
+        "Tf44", "Tf49", "Tf4A", "Tf4B", "Tf4D", "Tf4E"
+    ]
+
+    private nonisolated static let m3GPUKeys = [
+        "Tf14", "Tf18", "Tf19", "Tf1A", "Tf24", "Tf28", "Tf29", "Tf2A"
+    ]
+
+    private nonisolated static let m4CPUKeys = [
+        "Te05", "Te0S", "Te09", "Te0H",
+        "Tp01", "Tp05", "Tp09", "Tp0D", "Tp0V", "Tp0Y", "Tp0b", "Tp0e"
+    ]
+
+    private nonisolated static let m4GPUKeys = [
+        "Tg0G", "Tg0H", "Tg1U", "Tg1k",
+        "Tg0K", "Tg0L", "Tg0d", "Tg0e", "Tg0j", "Tg0k"
+    ]
+
+    private nonisolated static let m5CPUKeys = [
+        "Tp00", "Tp04", "Tp08", "Tp0C", "Tp0G", "Tp0K",
+        "Tp0O", "Tp0R", "Tp0U", "Tp0X", "Tp0a", "Tp0d",
+        "Tp0g", "Tp0j", "Tp0m", "Tp0p", "Tp0u", "Tp0y"
+    ]
+
+    private nonisolated static let m5GPUKeys = [
+        "Tg0U", "Tg0X", "Tg0d", "Tg0g", "Tg0j", "Tg1Y", "Tg1c", "Tg1g"
+    ]
+
+    private nonisolated static let appleStorageSensors = [
+        SMCStorageTemperatureSensor(key: "TH0x", label: "NAND (SMC)")
+    ]
+
+    private nonisolated static let intelStorageSensors = [
+        SMCStorageTemperatureSensor(key: "TH0A", label: "Drive A (SMC)"),
+        SMCStorageTemperatureSensor(key: "TH0B", label: "Drive B (SMC)"),
+        SMCStorageTemperatureSensor(key: "TH0C", label: "Drive C (SMC)")
+    ]
+
+    nonisolated static func sensors(chipName: String, isAppleSilicon: Bool) -> SMCTemperatureSensorSet {
+        guard isAppleSilicon else {
+            return SMCTemperatureSensorSet(
+                cpuKeys: intelCPUKeys,
+                gpuKeys: intelGPUKeys,
+                storageSensors: intelStorageSensors
+            )
+        }
+
+        let keys: (cpu: [String], gpu: [String])
+        switch generation(in: chipName) {
+        case 1:
+            keys = (m1CPUKeys, m1GPUKeys)
+        case 2:
+            keys = (m2CPUKeys, m2GPUKeys)
+        case 3:
+            keys = (m3CPUKeys, m3GPUKeys)
+        case 4:
+            keys = (m4CPUKeys, m4GPUKeys)
+        case 5:
+            keys = (m5CPUKeys, m5GPUKeys)
+        default:
+            keys = (
+                unique(m1CPUKeys + m2CPUKeys + m3CPUKeys + m4CPUKeys + m5CPUKeys),
+                unique(m1GPUKeys + m2GPUKeys + m3GPUKeys + m4GPUKeys + m5GPUKeys)
+            )
+        }
+
+        return SMCTemperatureSensorSet(
+            cpuKeys: keys.cpu,
+            gpuKeys: keys.gpu,
+            storageSensors: appleStorageSensors
+        )
+    }
+
+    nonisolated static func averageTemperature(
+        for keys: [String],
+        readValue: (String) -> Double?
+    ) -> Double? {
+        let values = keys.compactMap { key -> Double? in
+            guard let value = readValue(key), isValidTemperature(value, upperBound: 150) else {
+                return nil
+            }
+            return value
+        }
+
+        guard values.isEmpty == false else { return nil }
+        return values.reduce(0, +) / Double(values.count)
+    }
+
+    nonisolated static func firstStorageTemperature(
+        for sensors: [SMCStorageTemperatureSensor],
+        readValue: (String) -> Double?
+    ) -> (sensor: SMCStorageTemperatureSensor, value: Double)? {
+        for sensor in sensors {
+            guard let value = readValue(sensor.key), isValidTemperature(value, upperBound: 100) else {
+                continue
+            }
+            return (sensor, value)
+        }
+        return nil
+    }
+
+    private nonisolated static func generation(in chipName: String) -> Int? {
+        let tokens = chipName.uppercased().split { $0.isLetter == false && $0.isNumber == false }
+        for value in 1...5 where tokens.contains(Substring("M\(value)")) {
+            return value
+        }
+        return nil
+    }
+
+    private nonisolated static func isValidTemperature(_ value: Double, upperBound: Double) -> Bool {
+        value.isFinite && value > 0 && value < upperBound
+    }
+
+    private nonisolated static func unique(_ keys: [String]) -> [String] {
+        var seen = Set<String>()
+        return keys.filter { seen.insert($0).inserted }
+    }
+}
+
+enum SMCIOFloatDecoder {
+    nonisolated static func decode(_ bytes: [UInt8], dataSize: UInt32) -> Double? {
+        guard dataSize == 8, bytes.count >= 8 else { return nil }
+
+        var rawValue: UInt64 = 0
+        for index in (0..<8).reversed() {
+            rawValue = (rawValue << 8) | UInt64(bytes[index])
+        }
+        return Double(rawValue) / 65_536.0
+    }
+}

--- a/Core-Monitor/SMCTemperatureSensors.swift
+++ b/Core-Monitor/SMCTemperatureSensors.swift
@@ -127,6 +127,22 @@ enum SMCTemperatureSensorCatalog {
         return values.reduce(0, +) / Double(values.count)
     }
 
+    /// Returns the hottest reading among the given sensor keys instead of the average,
+    /// so a single hot core isn't masked by cooler sensors when reporting overall temperature.
+    nonisolated static func peakTemperature(
+        for keys: [String],
+        readValue: (String) -> Double?
+    ) -> Double? {
+        let values = keys.compactMap { key -> Double? in
+            guard let value = readValue(key), isValidTemperature(value, upperBound: 150) else {
+                return nil
+            }
+            return value
+        }
+
+        return values.max()
+    }
+
     nonisolated static func firstStorageTemperature(
         for sensors: [SMCStorageTemperatureSensor],
         readValue: (String) -> Double?

--- a/Core-Monitor/SystemMonitor.swift
+++ b/Core-Monitor/SystemMonitor.swift
@@ -605,13 +605,13 @@ final class SystemMonitor: ObservableObject {
     }
 
     private func readCPUTemperature() -> Double? {
-        SMCTemperatureSensorCatalog.averageTemperature(for: temperatureSensors.cpuKeys) { key in
+        SMCTemperatureSensorCatalog.peakTemperature(for: temperatureSensors.cpuKeys) { key in
             readSMCValue(key: key)
         }
     }
 
     private func readGPUTemperature() -> Double? {
-        SMCTemperatureSensorCatalog.averageTemperature(for: temperatureSensors.gpuKeys) { key in
+        SMCTemperatureSensorCatalog.peakTemperature(for: temperatureSensors.gpuKeys) { key in
             readSMCValue(key: key)
         }
     }

--- a/Core-Monitor/SystemMonitor.swift
+++ b/Core-Monitor/SystemMonitor.swift
@@ -196,11 +196,11 @@ final class SystemMonitor: ObservableObject {
     }
 
     static func chipName() -> String {
-        if let targetType = sysctlString(named: "hw.targettype"), !targetType.isEmpty {
-            return targetType
-        }
         if let brand = sysctlString(named: "machdep.cpu.brand_string"), !brand.isEmpty {
             return brand
+        }
+        if let targetType = sysctlString(named: "hw.targettype"), !targetType.isEmpty {
+            return targetType
         }
         return isAppleSilicon ? "Apple Silicon" : "Intel"
     }
@@ -245,6 +245,7 @@ final class SystemMonitor: ObservableObject {
     private var interactiveMonitoringReasons = Set<String>()
     private var monitoringIntervalOverrides: [String: TimeInterval] = [:]
     private let privacySettings: PrivacySettings
+    private let temperatureSensors: SMCTemperatureSensorSet
     private var cancellables = Set<AnyCancellable>()
 
     // MARK: - Basic mode adaptive polling
@@ -260,17 +261,8 @@ final class SystemMonitor: ObservableObject {
     private var previousProcessorLoadInfo: [integer_t] = []
     private var hasPreviousProcessorInfo = false
 
-    private let cpuTempKeys = [
-        "TC0P", "TCXC", "TC0E", "TC0F", "TC0D", "TC1C", "TC2C", "TC3C", "TC4C",
-        "Tp09", "Tp0T", "Tp01", "Tp05", "Tp0D", "Tp0b"
-    ]
-
-    private let gpuTempKeys = ["TGDD", "TG0P", "TG0D", "TG0E", "TG0F", "Tg0T", "Tg05"]
-
-    // SSD / NAND temperature keys
-    private let ssdTempKeys = ["TM0P", "Ts0S", "TH0A", "TH0B", "TH0C"]
-
     private let dataTypeFlt = fourCharCodeFrom("flt ")
+    private let dataTypeIoft = fourCharCodeFrom("ioft")
     private let dataTypeSp78 = fourCharCodeFrom("sp78")
     private let dataTypeFpe2 = fourCharCodeFrom("fpe2")
     private let dataTypeUInt8 = fourCharCodeFrom("ui8 ")
@@ -285,6 +277,10 @@ final class SystemMonitor: ObservableObject {
 
     init(privacySettings: PrivacySettings? = nil) {
         self.privacySettings = privacySettings ?? .shared
+        self.temperatureSensors = SMCTemperatureSensorCatalog.sensors(
+            chipName: Self.chipName(),
+            isAppleSilicon: Self.isAppleSilicon
+        )
         // The SMC connection is opened lazily on the sampling queue during the
         // first sample so all SMC state stays owned by that one queue.
         activitySampler.onUpdate = { [weak self] topProcesses in
@@ -464,7 +460,7 @@ final class SystemMonitor: ObservableObject {
             let diskStats = self.readDiskStats(now: sampledAt)
             let cpuPowerWatts = self.readSMCValue(key: "PCPU")
             let gpuPowerWatts = self.readSMCValue(key: "PGPU")
-            let ssdTemperature = self.readSSDTemperature()
+            let storageTemperature = self.readStorageTemperature()
             let networkStats = self.readNetworkStats()
             let thermalState = ProcessInfo.processInfo.thermalState
 
@@ -498,7 +494,13 @@ final class SystemMonitor: ObservableObject {
                 diskStats: diskStats,
                 cpuPowerWatts: cpuPowerWatts,
                 gpuPowerWatts: gpuPowerWatts,
-                ssdTemperature: ssdTemperature,
+                ssdTemperature: storageTemperature?.value,
+                storageTemperatureLabel: storageTemperature?.sensor.label
+                    ?? self.temperatureSensors.storageSensors.first?.label
+                    ?? "Storage (SMC)",
+                storageTemperatureNote: storageTemperature.map {
+                    "Sensor \($0.sensor.key). This may differ from NVMe SMART."
+                },
                 networkStats: networkStats,
                 thermalState: thermalState,
                 topProcesses: carriedTopProcesses,
@@ -603,30 +605,21 @@ final class SystemMonitor: ObservableObject {
     }
 
     private func readCPUTemperature() -> Double? {
-        for key in cpuTempKeys {
-            if let temp = readSMCValue(key: key), temp > 0, temp < 150 {
-                return temp
-            }
+        SMCTemperatureSensorCatalog.averageTemperature(for: temperatureSensors.cpuKeys) { key in
+            readSMCValue(key: key)
         }
-        return nil
     }
 
     private func readGPUTemperature() -> Double? {
-        for key in gpuTempKeys {
-            if let temp = readSMCValue(key: key), temp > 0, temp < 150 {
-                return temp
-            }
+        SMCTemperatureSensorCatalog.averageTemperature(for: temperatureSensors.gpuKeys) { key in
+            readSMCValue(key: key)
         }
-        return nil
     }
 
-    private func readSSDTemperature() -> Double? {
-        for key in ssdTempKeys {
-            if let temp = readSMCValue(key: key), temp > 0, temp < 100 {
-                return temp
-            }
+    private func readStorageTemperature() -> (sensor: SMCStorageTemperatureSensor, value: Double)? {
+        SMCTemperatureSensorCatalog.firstStorageTemperature(for: temperatureSensors.storageSensors) { key in
+            readSMCValue(key: key)
         }
-        return nil
     }
 
     // MARK: - Network throughput via getifaddrs
@@ -1129,6 +1122,9 @@ final class SystemMonitor: ObservableObject {
             if dataSize == 4 {
                 return decodeSMCFloat(raw, key: key)
             }
+
+        case dataTypeIoft:
+            return SMCIOFloatDecoder.decode(raw, dataSize: dataSize)
 
         case dataTypeSp78:
             if dataSize == 2 {

--- a/Core-Monitor/ThermalCoolingPages.swift
+++ b/Core-Monitor/ThermalCoolingPages.swift
@@ -14,7 +14,7 @@ struct ThermalPage: View {
             Panel {
                 HeroReading(
                     value: ReadingFormat.celsius(snapshot.cpuTemperature),
-                    label: "CPU temperature",
+                    label: "CPU average temperature",
                     tint: MetricTint.thermal,
                     severity: snapshot.cpuTemperature.map(ReadingThresholds.temperature) ?? .nominal
                 )
@@ -32,9 +32,13 @@ struct ThermalPage: View {
             }
 
             Panel("Sensors") {
-                temperatureRow("CPU", snapshot.cpuTemperature)
-                temperatureRow("GPU", snapshot.gpuTemperature)
-                temperatureRow("SSD", snapshot.ssdTemperature)
+                temperatureRow("CPU average", snapshot.cpuTemperature)
+                temperatureRow("GPU average", snapshot.gpuTemperature)
+                temperatureRow(
+                    snapshot.storageTemperatureLabel,
+                    snapshot.ssdTemperature,
+                    note: snapshot.storageTemperatureNote
+                )
                 if let battery = snapshot.batteryInfo.temperatureC {
                     temperatureRow("Battery", battery)
                 }
@@ -62,11 +66,12 @@ struct ThermalPage: View {
         }
     }
 
-    private func temperatureRow(_ label: String, _ value: Double?) -> some View {
+    private func temperatureRow(_ label: String, _ value: Double?, note: String? = nil) -> some View {
         let severity = value.map(ReadingThresholds.temperature) ?? .nominal
         return ReadingRow(
             label,
             value: ReadingFormat.celsiusLong(value),
+            note: note,
             valueColor: severity > .elevated ? severity.color : .primary
         )
     }

--- a/Core-MonitorTests/SMCTemperatureSensorCatalogTests.swift
+++ b/Core-MonitorTests/SMCTemperatureSensorCatalogTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+@testable import Core_Monitor
+
+final class SMCTemperatureSensorCatalogTests: XCTestCase {
+    func testCatalogUsesGenerationSpecificKeys() {
+        let cases = [
+            ("Apple M1 Max", "Tp0H", "Tg0D"),
+            ("Apple M2 Pro", "Tp1h", "Tg0f"),
+            ("Apple M3 Max", "Tf44", "Tf24"),
+            ("Apple M4", "Tp0V", "Tg0G"),
+            ("Apple M5 Pro", "Tp00", "Tg0U")
+        ]
+
+        for (chip, cpuKey, gpuKey) in cases {
+            let sensors = SMCTemperatureSensorCatalog.sensors(chipName: chip, isAppleSilicon: true)
+            XCTAssertTrue(sensors.cpuKeys.contains(cpuKey), chip)
+            XCTAssertTrue(sensors.gpuKeys.contains(gpuKey), chip)
+        }
+    }
+
+    func testUnknownAppleSiliconUsesKnownFallbackKeys() {
+        let sensors = SMCTemperatureSensorCatalog.sensors(
+            chipName: "Apple Silicon",
+            isAppleSilicon: true
+        )
+
+        XCTAssertTrue(sensors.cpuKeys.contains("Tp09"))
+        XCTAssertTrue(sensors.cpuKeys.contains("Tp00"))
+        XCTAssertTrue(sensors.gpuKeys.contains("Tg05"))
+        XCTAssertTrue(sensors.gpuKeys.contains("Tg0U"))
+        XCTAssertEqual(Set(sensors.cpuKeys).count, sensors.cpuKeys.count)
+        XCTAssertEqual(Set(sensors.gpuKeys).count, sensors.gpuKeys.count)
+    }
+
+    func testAverageTemperatureUsesEveryValidReading() {
+        let values: [String: Double] = [
+            "A": 40,
+            "B": 50,
+            "C": 60,
+            "D": -1,
+            "E": 200
+        ]
+
+        let average = SMCTemperatureSensorCatalog.averageTemperature(
+            for: ["A", "B", "C", "D", "E", "missing"],
+            readValue: { values[$0] }
+        )
+
+        XCTAssertEqual(average ?? 0, 50, accuracy: 0.001)
+    }
+
+    func testAppleStorageUsesTheNANDSensor() {
+        let sensors = SMCTemperatureSensorCatalog.sensors(
+            chipName: "Apple M4",
+            isAppleSilicon: true
+        )
+
+        XCTAssertEqual(
+            sensors.storageSensors,
+            [SMCStorageTemperatureSensor(key: "TH0x", label: "NAND (SMC)")]
+        )
+    }
+
+    func testIOFloatDecoderReadsLittleEndianFixedPoint() {
+        let value = SMCIOFloatDecoder.decode(
+            [0xcc, 0xcc, 0x21, 0, 0, 0, 0, 0],
+            dataSize: 8
+        )
+
+        XCTAssertEqual(value ?? 0, 33.8, accuracy: 0.01)
+        XCTAssertNil(SMCIOFloatDecoder.decode([0xcc, 0xcc, 0x21], dataSize: 8))
+    }
+}

--- a/smc-helper/main.swift
+++ b/smc-helper/main.swift
@@ -68,6 +68,7 @@ private final class SMCController {
 
     private let typeFpe2 = fourCharCodeFrom("fpe2")
     private let typeFlt = fourCharCodeFrom("flt ")
+    private let typeIoft = fourCharCodeFrom("ioft")
     private let typeUi8 = fourCharCodeFrom("ui8 ")
     private let typeUi16 = fourCharCodeFrom("ui16")
     private let conservativeMinimumRPM = 1_000
@@ -412,6 +413,14 @@ private final class SMCController {
 
         if dataType == typeFlt, dataSize == 4 {
             return decodeSMCFloat(raw, key: key)
+        }
+
+        if dataType == typeIoft, dataSize == 8 {
+            var value: UInt64 = 0
+            for index in (0..<8).reversed() {
+                value = (value << 8) | UInt64(raw[index])
+            }
+            return Double(value) / 65_536.0
         }
 
         return nil


### PR DESCRIPTION
## Change

- add CPU and GPU sensor keys for M1 through M5
- average all valid CPU and GPU readings
- restore M4 GPU readings
- label the TH0x source as NAND (SMC)
- decode 8-byte ioft values

## Verification

- helper build passed
- Swift source parse passed
- project file lint passed
- direct M1 Pro sensor probe passed
- focused tests added

Addresses #50.
Supports #49, #51, #52, and #53.