### PR TITLE
Fix temperature reporting, chart bounds, and CPU clusters

### DIFF
--- a/Core-Monitor/AlertEngine.swift
+++ b/Core-Monitor/AlertEngine.swift
@@ -238,7 +238,7 @@ enum AlertEvaluator {
     ) -> AlertMeasurement {
         switch kind {
         case .cpuTemperature:
-            guard let value = input.snapshot.cpuTemperature else {
+            guard let value = input.snapshot.cpuSafetyTemperature else {
                 return unavailable(kind, reason: "CPU temperature is unavailable on this Mac.")
             }
             let severity = severityForHighValue(value, threshold: config.threshold, activeSeverity: runtime.activeSeverity)
@@ -246,14 +246,14 @@ enum AlertEvaluator {
                 severity: severity,
                 metricValue: value,
                 title: severity == .critical ? "CPU temperature is critical" : "CPU temperature is elevated",
-                message: String(format: "CPU temperature reached %.0f°C.", value),
+                message: String(format: "CPU peak temperature reached %.0f°C.", value),
                 context: topCPUContext(from: input.snapshot.topProcesses, enabled: input.processInsightsEnabled),
                 isAvailable: true,
                 unavailableReason: nil
             )
 
         case .gpuTemperature:
-            guard let value = input.snapshot.gpuTemperature else {
+            guard let value = input.snapshot.gpuSafetyTemperature else {
                 return unavailable(kind, reason: "GPU temperature is unavailable on this Mac.")
             }
             let severity = severityForHighValue(value, threshold: config.threshold, activeSeverity: runtime.activeSeverity)
@@ -261,7 +261,7 @@ enum AlertEvaluator {
                 severity: severity,
                 metricValue: value,
                 title: severity == .critical ? "GPU temperature is critical" : "GPU temperature is elevated",
-                message: String(format: "GPU temperature reached %.0f°C.", value),
+                message: String(format: "GPU peak temperature reached %.0f°C.", value),
                 context: topCPUContext(from: input.snapshot.topProcesses, enabled: input.processInsightsEnabled),
                 isAvailable: true,
                 unavailableReason: nil
@@ -323,7 +323,7 @@ enum AlertEvaluator {
             guard input.snapshot.numberOfFans > 0 else {
                 return unavailable(kind, reason: "No fan sensors were detected on this Mac.")
             }
-            let hottest = max(input.snapshot.cpuTemperature ?? 0, input.snapshot.gpuTemperature ?? 0)
+            let hottest = max(input.snapshot.cpuSafetyTemperature ?? 0, input.snapshot.gpuSafetyTemperature ?? 0)
             guard hottest > 0 else {
                 return AlertMeasurement(
                     severity: .none,

--- a/Core-Monitor/FanController.swift
+++ b/Core-Monitor/FanController.swift
@@ -798,8 +798,8 @@ final class FanController: ObservableObject {
     private func updateSmartProfile() {
         guard let monitor = systemMonitor else { return }
 
-        let cpuTemp = monitor.cpuTemperature ?? 0
-        let gpuTemp = monitor.gpuTemperature ?? 0
+        let cpuTemp = monitor.cpuSafetyTemperature ?? 0
+        let gpuTemp = monitor.gpuSafetyTemperature ?? 0
         let maxTemp = max(cpuTemp, gpuTemp)
         guard maxTemp > 0 else { return }
 
@@ -846,8 +846,8 @@ final class FanController: ObservableObject {
             return
         }
 
-        let cpuTemp = monitor.cpuTemperature ?? 0
-        let gpuTemp = monitor.gpuTemperature ?? 0
+        let cpuTemp = monitor.cpuSafetyTemperature ?? 0
+        let gpuTemp = monitor.gpuSafetyTemperature ?? 0
 
         let baseTemperature: Double
         let sensorLabel: String

--- a/Core-Monitor/MenuBarPopovers.swift
+++ b/Core-Monitor/MenuBarPopovers.swift
@@ -96,7 +96,7 @@ struct MetricPopoverView: View {
         case .memory: return "of \(ReadingFormat.gigabytes(snapshot.totalMemoryGB))"
         case .disk: return "used"
         case .network: return "↑ " + ReadingFormat.rate(snapshot.networkStats.uploadBytesPerSec)
-        case .temperature: return "CPU"
+        case .temperature: return "CPU average"
         case .fan:
             let active = snapshot.fanSpeeds.filter { $0 > 0 }.count
             if active == 0 { return "fans idle" }
@@ -115,7 +115,7 @@ struct MetricPopoverView: View {
         case .network, .fan:
             return .nominal
         case .temperature:
-            return snapshot.cpuTemperature.map(ReadingThresholds.temperature) ?? .nominal
+            return snapshot.cpuSafetyTemperature.map(ReadingThresholds.temperature) ?? .nominal
         }
     }
 
@@ -223,7 +223,9 @@ struct MetricPopoverView: View {
 
         case .temperature:
             var stats: [(String, String)] = [
+                ("CPU peak", ReadingFormat.celsiusLong(snapshot.cpuPeakTemperature)),
                 ("GPU average", ReadingFormat.celsiusLong(snapshot.gpuTemperature)),
+                ("GPU peak", ReadingFormat.celsiusLong(snapshot.gpuPeakTemperature)),
                 (snapshot.storageTemperatureLabel, ReadingFormat.celsiusLong(snapshot.ssdTemperature))
             ]
             if let fastest = snapshot.fanSpeeds.filter({ $0 > 0 }).max() {

--- a/Core-Monitor/MenubarController.swift
+++ b/Core-Monitor/MenubarController.swift
@@ -274,7 +274,8 @@ final class SingleMenuBarItemController: NSObject, NSPopoverDelegate {
         case .temperature:
             if let t = systemMonitor.cpuTemperature {
                 let ti = Int(t.rounded())
-                let tone: StatusTone = t > 90 ? .critical : t > 70 ? .warning : .normal
+                let safetyTemperature = systemMonitor.cpuSafetyTemperature ?? t
+                let tone: StatusTone = safetyTemperature > 90 ? .critical : safetyTemperature > 70 ? .warning : .normal
                 return ("\(ti)°", tone)
             }
             return ("—°", .secondary)

--- a/Core-Monitor/MonitorDesign.swift
+++ b/Core-Monitor/MonitorDesign.swift
@@ -285,10 +285,12 @@ struct TrendChart: View {
                 }
                 .frame(maxWidth: .infinity, minHeight: height)
             } else {
+                let domain = resolvedDomain(for: visible)
                 Chart(visible, id: \.timestamp) { point in
                     AreaMark(
                         x: .value("Time", point.timestamp),
-                        y: .value("Value", point.value)
+                        yStart: .value("Scale minimum", domain.lowerBound),
+                        yEnd: .value("Value", point.value)
                     )
                     .interpolationMethod(.monotone)
                     .foregroundStyle(
@@ -307,8 +309,14 @@ struct TrendChart: View {
                     .foregroundStyle(tint)
                     .lineStyle(StrokeStyle(lineWidth: 1.5))
                 }
-                .chartXScale(domain: Date().addingTimeInterval(-range.duration)...Date())
-                .chartYScale(domain: resolvedDomain(for: visible))
+                .chartXScale(
+                    domain: Date().addingTimeInterval(-range.duration)...Date(),
+                    range: .plotDimension(startPadding: 6, endPadding: 6)
+                )
+                .chartYScale(
+                    domain: domain,
+                    range: .plotDimension(startPadding: 6, endPadding: 6)
+                )
                 .chartXAxis {
                     AxisMarks(values: .automatic(desiredCount: 3)) { _ in
                         AxisGridLine()
@@ -377,6 +385,8 @@ struct Sparkline: View {
                 .chartXAxis(.hidden)
                 .chartYAxis(.hidden)
                 .chartLegend(.hidden)
+                .chartXScale(range: .plotDimension(startPadding: 3, endPadding: 3))
+                .chartYScale(range: .plotDimension(startPadding: 3, endPadding: 3))
                 .frame(height: height)
             }
         }

--- a/Core-Monitor/MonitorSection.swift
+++ b/Core-Monitor/MonitorSection.swift
@@ -81,7 +81,7 @@ enum SystemStatusNarrator {
         if snapshot.memoryPressure == .yellow {
             return "Running fine, with elevated memory pressure."
         }
-        if let temperature = snapshot.cpuTemperature, temperature >= 70 {
+        if let temperature = snapshot.cpuSafetyTemperature, temperature >= 70 {
             return "Running warm but within normal limits."
         }
         return "Running cool. Everything looks normal."

--- a/Core-Monitor/MonitoringSnapshot.swift
+++ b/Core-Monitor/MonitoringSnapshot.swift
@@ -186,6 +186,8 @@ struct SystemMonitorSnapshot {
     var sampledAt: Date = .distantPast
     var cpuTemperature: Double?
     var gpuTemperature: Double?
+    var cpuPeakTemperature: Double?
+    var gpuPeakTemperature: Double?
     var fanSpeeds: [Int] = []
     var fanMinSpeeds: [Int] = []
     var fanMaxSpeeds: [Int] = []
@@ -220,6 +222,14 @@ struct SystemMonitorSnapshot {
     var topProcesses: TopProcessSnapshot = .empty
     var hasSMCAccess: Bool = false
     var lastError: String?
+
+    var cpuSafetyTemperature: Double? {
+        cpuPeakTemperature ?? cpuTemperature
+    }
+
+    var gpuSafetyTemperature: Double? {
+        gpuPeakTemperature ?? gpuTemperature
+    }
 
     static let empty = SystemMonitorSnapshot()
 }

--- a/Core-Monitor/OverviewPage.swift
+++ b/Core-Monitor/OverviewPage.swift
@@ -82,7 +82,7 @@ struct OverviewPage: View {
             section: .thermal,
             reading: ReadingFormat.celsius(snapshot.cpuTemperature),
             caption: thermalCaption(snapshot),
-            severity: snapshot.cpuTemperature.map(ReadingThresholds.temperature)
+            severity: snapshot.cpuSafetyTemperature.map(ReadingThresholds.temperature)
                 ?? ReadingThresholds.thermalState(snapshot.thermalState),
             points: systemMonitor.cpuTemperatureTrend.points,
             openSection: openSection

--- a/Core-Monitor/SMCTemperatureSensors.swift
+++ b/Core-Monitor/SMCTemperatureSensors.swift
@@ -11,6 +11,11 @@ struct SMCTemperatureSensorSet: Equatable, Sendable {
     let storageSensors: [SMCStorageTemperatureSensor]
 }
 
+struct SMCTemperatureSummary: Equatable, Sendable {
+    let average: Double
+    let peak: Double
+}
+
 enum SMCTemperatureSensorCatalog {
     private nonisolated static let intelCPUKeys = [
         "TC0P", "TCXC", "TC0E", "TC0F", "TC0D", "TC1C", "TC2C", "TC3C", "TC4C"
@@ -116,23 +121,20 @@ enum SMCTemperatureSensorCatalog {
         for keys: [String],
         readValue: (String) -> Double?
     ) -> Double? {
-        let values = keys.compactMap { key -> Double? in
-            guard let value = readValue(key), isValidTemperature(value, upperBound: 150) else {
-                return nil
-            }
-            return value
-        }
-
-        guard values.isEmpty == false else { return nil }
-        return values.reduce(0, +) / Double(values.count)
+        temperatureSummary(for: keys, readValue: readValue)?.average
     }
 
-    /// Returns the hottest reading among the given sensor keys instead of the average,
-    /// so a single hot core isn't masked by cooler sensors when reporting overall temperature.
     nonisolated static func peakTemperature(
         for keys: [String],
         readValue: (String) -> Double?
     ) -> Double? {
+        temperatureSummary(for: keys, readValue: readValue)?.peak
+    }
+
+    nonisolated static func temperatureSummary(
+        for keys: [String],
+        readValue: (String) -> Double?
+    ) -> SMCTemperatureSummary? {
         let values = keys.compactMap { key -> Double? in
             guard let value = readValue(key), isValidTemperature(value, upperBound: 150) else {
                 return nil
@@ -140,7 +142,11 @@ enum SMCTemperatureSensorCatalog {
             return value
         }
 
-        return values.max()
+        guard let peak = values.max() else { return nil }
+        return SMCTemperatureSummary(
+            average: values.reduce(0, +) / Double(values.count),
+            peak: peak
+        )
     }
 
     nonisolated static func firstStorageTemperature(

--- a/Core-Monitor/SystemMonitor.swift
+++ b/Core-Monitor/SystemMonitor.swift
@@ -11,6 +11,29 @@ struct CPUStats {
     let efficiencyCoreUsagePercent: Double?
 }
 
+struct CPUClusterProcessorRanges: Equatable {
+    let performance: Range<Int>
+    let efficiency: Range<Int>?
+
+    static func resolve(
+        cpuCount: Int,
+        performanceCoreCount: Int,
+        efficiencyCoreCount: Int
+    ) -> CPUClusterProcessorRanges? {
+        let performanceCount = min(max(performanceCoreCount, 0), cpuCount)
+        let efficiencyCount = min(max(efficiencyCoreCount, 0), max(0, cpuCount - performanceCount))
+        guard performanceCount > 0, performanceCount + efficiencyCount <= cpuCount else {
+            return nil
+        }
+
+        let performanceStart = efficiencyCount
+        return CPUClusterProcessorRanges(
+            performance: performanceStart..<(performanceStart + performanceCount),
+            efficiency: efficiencyCount > 0 ? 0..<efficiencyCount : nil
+        )
+    }
+}
+
 enum MemoryPressureLevel {
     case green
     case yellow
@@ -120,6 +143,8 @@ final class SystemMonitor: ObservableObject {
 
     var cpuTemperature: Double? { snapshot.cpuTemperature }
     var gpuTemperature: Double? { snapshot.gpuTemperature }
+    var cpuSafetyTemperature: Double? { snapshot.cpuSafetyTemperature }
+    var gpuSafetyTemperature: Double? { snapshot.gpuSafetyTemperature }
     var fanSpeeds: [Int] { snapshot.fanSpeeds }
     var fanMinSpeeds: [Int] { snapshot.fanMinSpeeds }
     var fanMaxSpeeds: [Int] { snapshot.fanMaxSpeeds }
@@ -466,8 +491,10 @@ final class SystemMonitor: ObservableObject {
 
             var snapshot = SystemMonitorSnapshot(
                 sampledAt: sampledAt,
-                cpuTemperature: cpuTemperature,
-                gpuTemperature: gpuTemperature,
+                cpuTemperature: cpuTemperature?.average,
+                gpuTemperature: gpuTemperature?.average,
+                cpuPeakTemperature: cpuTemperature?.peak,
+                gpuPeakTemperature: gpuTemperature?.peak,
                 fanSpeeds: fanReadings.speeds,
                 fanMinSpeeds: fanReadings.mins,
                 fanMaxSpeeds: fanReadings.maxs,
@@ -604,14 +631,14 @@ final class SystemMonitor: ObservableObject {
         snapshot = updatedSnapshot
     }
 
-    private func readCPUTemperature() -> Double? {
-        SMCTemperatureSensorCatalog.peakTemperature(for: temperatureSensors.cpuKeys) { key in
+    private func readCPUTemperature() -> SMCTemperatureSummary? {
+        SMCTemperatureSensorCatalog.temperatureSummary(for: temperatureSensors.cpuKeys) { key in
             readSMCValue(key: key)
         }
     }
 
-    private func readGPUTemperature() -> Double? {
-        SMCTemperatureSensorCatalog.peakTemperature(for: temperatureSensors.gpuKeys) { key in
+    private func readGPUTemperature() -> SMCTemperatureSummary? {
+        SMCTemperatureSensorCatalog.temperatureSummary(for: temperatureSensors.gpuKeys) { key in
             readSMCValue(key: key)
         }
     }
@@ -826,18 +853,21 @@ final class SystemMonitor: ObservableObject {
 
         defer { previousProcessorLoadInfo = sample }
 
-        let pCoreCount = min(SystemMonitor.performanceCoreCount(), cpuCount)
-        let eCoreCount = min(SystemMonitor.efficiencyCoreCount(), max(0, cpuCount - pCoreCount))
-        guard pCoreCount > 0, pCoreCount + eCoreCount <= cpuCount else {
+        guard let clusterRanges = CPUClusterProcessorRanges.resolve(
+            cpuCount: cpuCount,
+            performanceCoreCount: SystemMonitor.performanceCoreCount(),
+            efficiencyCoreCount: SystemMonitor.efficiencyCoreCount()
+        ) else {
             return (performanceCoreUsagePercent, efficiencyCoreUsagePercent)
         }
 
-        let performanceUsage = usageForProcessorRange(0..<pCoreCount, current: sample, previous: previousProcessorLoadInfo)
-        let efficiencyUsage: Double?
-        if eCoreCount > 0 {
-            efficiencyUsage = usageForProcessorRange(pCoreCount..<(pCoreCount + eCoreCount), current: sample, previous: previousProcessorLoadInfo)
-        } else {
-            efficiencyUsage = nil
+        let performanceUsage = usageForProcessorRange(
+            clusterRanges.performance,
+            current: sample,
+            previous: previousProcessorLoadInfo
+        )
+        let efficiencyUsage = clusterRanges.efficiency.flatMap {
+            usageForProcessorRange($0, current: sample, previous: previousProcessorLoadInfo)
         }
 
         return (performanceUsage, efficiencyUsage)

--- a/Core-Monitor/ThermalCoolingPages.swift
+++ b/Core-Monitor/ThermalCoolingPages.swift
@@ -16,7 +16,7 @@ struct ThermalPage: View {
                     value: ReadingFormat.celsius(snapshot.cpuTemperature),
                     label: "CPU average temperature",
                     tint: MetricTint.thermal,
-                    severity: snapshot.cpuTemperature.map(ReadingThresholds.temperature) ?? .nominal
+                    severity: snapshot.cpuSafetyTemperature.map(ReadingThresholds.temperature) ?? .nominal
                 )
                 TrendRangePicker(range: $range)
                 TrendChart(
@@ -33,7 +33,9 @@ struct ThermalPage: View {
 
             Panel("Sensors") {
                 temperatureRow("CPU average", snapshot.cpuTemperature)
+                temperatureRow("CPU peak", snapshot.cpuPeakTemperature)
                 temperatureRow("GPU average", snapshot.gpuTemperature)
+                temperatureRow("GPU peak", snapshot.gpuPeakTemperature)
                 temperatureRow(
                     snapshot.storageTemperatureLabel,
                     snapshot.ssdTemperature,

--- a/Core-MonitorTests/AlertEngineTests.swift
+++ b/Core-MonitorTests/AlertEngineTests.swift
@@ -30,6 +30,31 @@ final class AlertEngineTests: XCTestCase {
         XCTAssertEqual(criticalOutcome.event?.severity, .critical)
     }
 
+    func testPeakTemperatureDrivesSafetyWithoutReplacingAverage() {
+        let config = AlertRuleConfig(
+            kind: .cpuTemperature,
+            isEnabled: true,
+            threshold: .init(warning: 80, critical: 90, hysteresis: 3),
+            cooldownMinutes: 10,
+            debounceSamples: 1,
+            desktopNotificationsEnabled: true
+        )
+
+        let input = makeInput { snapshot in
+            snapshot.cpuTemperature = 60
+            snapshot.cpuPeakTemperature = 96
+        }
+        let outcome = AlertEvaluator.evaluate(
+            config: config,
+            runtime: .initial(for: .cpuTemperature),
+            input: input
+        )
+
+        XCTAssertEqual(input.snapshot.cpuTemperature, 60)
+        XCTAssertEqual(outcome.activeState?.severity, .critical)
+        XCTAssertEqual(outcome.runtime.lastMetricValue, 96)
+    }
+
     func testHysteresisKeepsAlertActiveUntilMetricRecoversPastFloor() {
         let config = AlertRuleConfig(
             kind: .cpuTemperature,

--- a/Core-MonitorTests/SMCTemperatureSensorCatalogTests.swift
+++ b/Core-MonitorTests/SMCTemperatureSensorCatalogTests.swift
@@ -2,6 +2,28 @@ import XCTest
 @testable import Core_Monitor
 
 final class SMCTemperatureSensorCatalogTests: XCTestCase {
+    func testAppleSiliconClusterRangesPutEfficiencyCoresFirst() {
+        let ranges = CPUClusterProcessorRanges.resolve(
+            cpuCount: 8,
+            performanceCoreCount: 6,
+            efficiencyCoreCount: 2
+        )
+
+        XCTAssertEqual(ranges?.efficiency, 0..<2)
+        XCTAssertEqual(ranges?.performance, 2..<8)
+    }
+
+    func testSingleClusterUsesTheFullProcessorRange() {
+        let ranges = CPUClusterProcessorRanges.resolve(
+            cpuCount: 12,
+            performanceCoreCount: 12,
+            efficiencyCoreCount: 0
+        )
+
+        XCTAssertNil(ranges?.efficiency)
+        XCTAssertEqual(ranges?.performance, 0..<12)
+    }
+
     func testCatalogUsesGenerationSpecificKeys() {
         let cases = [
             ("Apple M1 Max", "Tp0H", "Tg0D"),
@@ -32,7 +54,7 @@ final class SMCTemperatureSensorCatalogTests: XCTestCase {
         XCTAssertEqual(Set(sensors.gpuKeys).count, sensors.gpuKeys.count)
     }
 
-    func testAverageTemperatureUsesEveryValidReading() {
+    func testTemperatureSummaryUsesEveryValidReading() {
         let values: [String: Double] = [
             "A": 40,
             "B": 50,
@@ -41,12 +63,18 @@ final class SMCTemperatureSensorCatalogTests: XCTestCase {
             "E": 200
         ]
 
-        let average = SMCTemperatureSensorCatalog.averageTemperature(
+        var reads: [String] = []
+        let summary = SMCTemperatureSensorCatalog.temperatureSummary(
             for: ["A", "B", "C", "D", "E", "missing"],
-            readValue: { values[$0] }
+            readValue: {
+                reads.append($0)
+                return values[$0]
+            }
         )
 
-        XCTAssertEqual(average ?? 0, 50, accuracy: 0.001)
+        XCTAssertEqual(summary?.average ?? 0, 50, accuracy: 0.001)
+        XCTAssertEqual(summary?.peak ?? 0, 60, accuracy: 0.001)
+        XCTAssertEqual(reads, ["A", "B", "C", "D", "E", "missing"])
     }
 
     func testAppleStorageUsesTheNANDSensor() {


### PR DESCRIPTION
Summary:
- restore average CPU and GPU readings while using peaks for alerts and cooling
- keep chart lines and fills inside the plot
- correct Apple silicon performance and efficiency core ranges

Tests:
- xcodebuild test -project Core-Monitor.xcodeproj -scheme Core-Monitor -destination platform=macOS
- checked the CPU and Thermal pages in the rebuilt app