### PR TITLE
Add privacy section to the website

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -41,7 +41,7 @@
        fetched at the same priority as the stylesheet rather than waiting for
        the parser to reach the <img>. -->
   <link rel="preload" as="image" href="images/ui/overview-v16.png?v=16" fetchpriority="high">
-  <link rel="stylesheet" href="styles.css?v=18">
+  <link rel="stylesheet" href="styles.css?v=19">
   <!-- Type is set in the system UI font (SF Pro on macOS), so there are no
        webfont requests and nothing about a visitor reaches a third party. -->
   <script src="script.js?v=8" defer></script>
@@ -326,6 +326,39 @@
             <p>Stats, optional live weather, shortcuts and memory pressure, arranged with a live width preview so a layout never runs off the edge of the strip. Live weather stays off until you enable it. The strip holds its place across apps, so you can check a reading or launch something without switching windows.</p>
           </div>
         </figure>
+      </div>
+    </section>
+
+    <section class="privacy-section" id="privacy" aria-labelledby="privacy-title">
+      <div class="privacy-layout">
+        <h2 id="privacy-title">Your Mac has<br>a private life.<br>Keep it that way.</h2>
+        <div class="privacy-copy">
+          <p>Core-Monitor reads your system, then keeps that data on your Mac. There is no account to create and no telemetry to switch off.</p>
+          <div class="privacy-facts">
+            <p>
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <rect x="5" y="10" width="14" height="11" rx="2"/>
+                <path d="M8 10V7a4 4 0 0 1 8 0v3m-4 5v2"/>
+              </svg>
+              Local data
+            </p>
+            <p>
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <circle cx="12" cy="7" r="4"/>
+                <path d="M4 21v-2a8 8 0 0 1 16 0v2"/>
+              </svg>
+              No account
+            </p>
+            <p>
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path d="m8 6-6 6 6 6m8-12 6 6-6 6m-3-15-2 18"/>
+              </svg>
+              Open source
+            </p>
+          </div>
+          <p class="privacy-footnote">Live Weather is off by default. If you enable it, Apple WeatherKit receives your location after you grant permission.</p>
+          <a class="privacy-source" href="https://github.com/offyotto/Core-Monitor">Read the source code</a>
+        </div>
       </div>
     </section>
 

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1059,3 +1059,117 @@ h1, h2, h3 { text-wrap: balance; }
 
   ::selection { background: rgba(0, 105, 217, 0.2); }
 }
+
+/* Privacy section. These styles do not affect the rest of the website. */
+.privacy-section {
+  padding-block: 110px;
+  background: #0b1016;
+  color: #edf2f6;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 16px;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+.privacy-section .privacy-layout {
+  display: grid;
+  grid-template-columns: 1.1fr 1fr;
+  gap: 100px;
+  width: min(1280px, calc(100% - 112px));
+  margin-inline: auto;
+  padding-top: 95px;
+  border-top: 1px solid #ffffff19;
+}
+
+.privacy-section h2 {
+  max-width: 550px;
+  margin: 0;
+  font-size: clamp(2.4rem, 4.4vw, 4.4rem);
+  font-weight: 500;
+  line-height: 1.08;
+  letter-spacing: -.055em;
+  text-wrap: balance;
+}
+
+.privacy-section .privacy-copy > p {
+  margin: 0 0 26px;
+  color: #a4b0bd;
+  font-size: 18px;
+}
+
+.privacy-section .privacy-facts {
+  display: flex;
+  gap: 30px;
+  margin-block: 35px;
+}
+
+.privacy-section .privacy-facts p {
+  margin: 0;
+  color: #edf2f6;
+  font-size: 14px;
+}
+
+.privacy-section .privacy-facts svg {
+  display: block;
+  width: 22px;
+  height: 22px;
+  margin-bottom: 12px;
+  fill: none;
+  stroke: #b8d8ef;
+  stroke-width: 1.6;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.privacy-section .privacy-copy .privacy-footnote {
+  font-size: 13px;
+}
+
+.privacy-section .privacy-source {
+  display: inline-flex;
+  align-items: center;
+  color: #edf2f6;
+  font-size: 14px;
+  text-decoration: underline;
+  text-underline-offset: 5px;
+  text-decoration-color: #ffffff50;
+}
+
+.privacy-section .privacy-source:hover {
+  text-decoration-color: currentColor;
+}
+
+.privacy-section :focus-visible {
+  outline: 2px solid #b8d8ef;
+  outline-offset: 6px;
+}
+
+@media (max-width: 1150px) {
+  .privacy-section .privacy-layout {
+    width: calc(100% - 72px);
+    gap: 60px;
+  }
+}
+
+@media (max-width: 850px) {
+  .privacy-section {
+    padding-block: 65px;
+  }
+
+  .privacy-section .privacy-layout {
+    grid-template-columns: 1fr;
+    gap: 45px;
+    width: calc(100% - 48px);
+    padding-top: 65px;
+  }
+}
+
+@media (max-width: 540px) {
+  .privacy-section .privacy-layout {
+    width: calc(100% - 36px);
+  }
+
+  .privacy-section .privacy-facts {
+    gap: 25px;
+  }
+}


### PR DESCRIPTION
## Change

Add the “Your Mac has a private life. Keep it that way.” section to the existing homepage. Preserve its text, typography, icons, and layout from the preview. Scope the CSS to this section and update the stylesheet cache version.

## Verification

- Checked desktop and narrow layouts, with no horizontal overflow.
- Checked local links, assets, unique IDs, and page headings.
- Confirmed all five other website files match their original contents.
- Ran `git diff --check`.
